### PR TITLE
Read the 4quare config from a git-ignored plist

### DIFF
--- a/Configuration/foursquare_api_configuration.plist
+++ b/Configuration/foursquare_api_configuration.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>client_id</key>
+	<string></string>
+	<key>client_secret</key>
+	<string></string>
+	<key>callback_uri</key>
+	<string></string>
+</dict>
+</plist>

--- a/Configuration/foursquare_api_configuration_instructions
+++ b/Configuration/foursquare_api_configuration_instructions
@@ -1,0 +1,5 @@
+Update the foursquare_api_configuration plist with your Foursquare configuration values.
+Before doing so execute "git update-index --assume-unchanged Configuration/foursquare_api_configuration.plist".
+You can obtain client_id and client_secret after registering your Foursquare application here: https://foursquare.com/developers/register
+When doing so, you need to specify a redirect URL. The one you specify should be added to the plist and registered as a valid URL scheme for the app.
+Note: this is an example project and that's why the client secret is read from a plist, if you want to build a proper app consider storing the client secret on your server and modify the authentication code. Check how to implement the auth flow here: https://github.com/foursquare/foursquare-ios-oauth/

--- a/TripCheckins.xcodeproj/project.pbxproj
+++ b/TripCheckins.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		E14559851F45E2C60008E0ED /* DateFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14559841F45E2C60008E0ED /* DateFilter.swift */; };
 		E14559871F4DCF4E0008E0ED /* AddTripDateFilterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14559861F4DCF4E0008E0ED /* AddTripDateFilterViewModelTests.swift */; };
 		E14A55661F5CC76E00796065 /* UIColor+TripCheckins.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14A55651F5CC76E00796065 /* UIColor+TripCheckins.swift */; };
+		E154620E1F7C39F700218D9B /* foursquare_api_configuration.plist in Resources */ = {isa = PBXBuildFile; fileRef = E154620D1F7C39F700218D9B /* foursquare_api_configuration.plist */; };
 		E156EC551F39ECA3006AF828 /* FoursquareAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E156EC541F39ECA3006AF828 /* FoursquareAuthorizer.swift */; };
 		E156EC571F39F486006AF828 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E156EC561F39F486006AF828 /* AppCoordinator.swift */; };
 		E16ED3621F39DB0500963177 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ED3611F39DB0500963177 /* AppDelegate.swift */; };
@@ -83,6 +84,7 @@
 		E14559841F45E2C60008E0ED /* DateFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFilter.swift; sourceTree = "<group>"; };
 		E14559861F4DCF4E0008E0ED /* AddTripDateFilterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTripDateFilterViewModelTests.swift; sourceTree = "<group>"; };
 		E14A55651F5CC76E00796065 /* UIColor+TripCheckins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+TripCheckins.swift"; sourceTree = "<group>"; };
+		E154620D1F7C39F700218D9B /* foursquare_api_configuration.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = foursquare_api_configuration.plist; path = Configuration/foursquare_api_configuration.plist; sourceTree = SOURCE_ROOT; };
 		E156EC501F39EB89006AF828 /* TripCheckins-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TripCheckins-Bridging-Header.h"; sourceTree = "<group>"; };
 		E156EC541F39ECA3006AF828 /* FoursquareAuthorizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareAuthorizer.swift; sourceTree = "<group>"; };
 		E156EC561F39F486006AF828 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
@@ -295,6 +297,7 @@
 				E1D528F41F3A0651000D52C1 /* UserDefaults+AuthorizationTokenKeeper.swift */,
 				E16ED3631F39DB0500963177 /* FoursquareAuthorizationViewController.swift */,
 				E156EC541F39ECA3006AF828 /* FoursquareAuthorizer.swift */,
+				E154620D1F7C39F700218D9B /* foursquare_api_configuration.plist */,
 			);
 			name = "Foursquare Authorization";
 			path = Authorization;
@@ -420,6 +423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E16ED36C1F39DB0500963177 /* LaunchScreen.storyboard in Resources */,
+				E154620E1F7C39F700218D9B /* foursquare_api_configuration.plist in Resources */,
 				E1D529001F3B023A000D52C1 /* CompactCheckinTableViewCell.xib in Resources */,
 				E16ED3691F39DB0500963177 /* Assets.xcassets in Resources */,
 			);

--- a/TripCheckins/Application flow/AppCoordinator.swift
+++ b/TripCheckins/Application flow/AppCoordinator.swift
@@ -33,13 +33,14 @@ class AppCoordinator {
     
     // MARK: - Private
     private func showAuthorizationViewController() {
-        if let foursquareAuthorizer = FoursquareAuthorizer() {
+        do {
+            let foursquareAuthorizer = try FoursquareAuthorizer()
             let viewController = FoursquareAuthorizationViewController(foursquareAuthorizer: foursquareAuthorizer)
             viewController.delegate = self
             pushViewController(viewController)
             self.foursquareAuthorizer = foursquareAuthorizer
-        } else {
-            // TODO: handle auth error
+        } catch let error {
+            print(error)
         }
     }
     

--- a/TripCheckins/Application flow/AppCoordinator.swift
+++ b/TripCheckins/Application flow/AppCoordinator.swift
@@ -33,11 +33,14 @@ class AppCoordinator {
     
     // MARK: - Private
     private func showAuthorizationViewController() {
-        let foursquareAuthorizer = FoursquareAuthorizer()
-        let viewController = FoursquareAuthorizationViewController(foursquareAuthorizer: foursquareAuthorizer)
-        viewController.delegate = self
-        pushViewController(viewController)
-        self.foursquareAuthorizer = foursquareAuthorizer
+        if let foursquareAuthorizer = FoursquareAuthorizer() {
+            let viewController = FoursquareAuthorizationViewController(foursquareAuthorizer: foursquareAuthorizer)
+            viewController.delegate = self
+            pushViewController(viewController)
+            self.foursquareAuthorizer = foursquareAuthorizer
+        } else {
+            // TODO: handle auth error
+        }
     }
     
     private func showCheckinsList(authorizationToken token:String) {

--- a/TripCheckins/Authorization/FoursquareAuthorizer.swift
+++ b/TripCheckins/Authorization/FoursquareAuthorizer.swift
@@ -14,9 +14,26 @@ protocol FoursquareAuthorizerDelegate: class {
 
 final class FoursquareAuthorizer {
     
-    private let clientId = "SO0SBDKGOYSZCH4JMQOEHJHMNTETYOWCURGWAZ22BPHKQDWE"
-    private let clientSecret = "KBYTRDYUXSUULW4P4YDELCDQVF3FZ1ZKNHLJOF0MLZ2CGUMQ"
-    private let callbackURIString = "tripcheckins://foursquare"
+    private let clientId: String
+    private let clientSecret: String
+    private let callbackURIString: String
+    
+    convenience init?() {
+        guard let plistPath = Bundle.main.path(forResource: "foursquare_api_configuration", ofType: "plist"),
+            let configuration = NSDictionary(contentsOfFile: plistPath) as? [String: String],
+            let clientId = configuration["client_id"],
+            let clientSecret = configuration["client_secret"],
+            let callbackURIString = configuration["callback_uri"] else {
+                return nil
+        }
+        self.init(clientId: clientId, clientSecret: clientSecret, callbackURIString: callbackURIString)
+    }
+    
+    init(clientId: String, clientSecret: String, callbackURIString: String) {
+        self.clientId = clientId
+        self.clientSecret = clientSecret
+        self.callbackURIString = callbackURIString
+    }
     
     weak var delegate: FoursquareAuthorizerDelegate?
     


### PR DESCRIPTION
Removing the private keys from the repo and including an empty plist that can be used for adding new keys following the included instructions.